### PR TITLE
Updated new issue link so it shows the templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ To see [upcoming plans for the Network](https://github.com/codeforamerica/networ
 
 ### Submit your idea for the Network
 
-Have an idea for something that staff could work on? [Submit an issue on this repo by going here](https://github.com/codeforamerica/network/issues/new). We commit to responding and reviewing ideas on a quarterly basis (4x/year). If you have an immediate request, please go through the normal channels of contacting staff or submitting a support request.
+Have an idea for something that staff could work on? [Submit an issue on this repo by going here](https://github.com/codeforamerica/network/issues/new/choose). We commit to responding and reviewing ideas on a quarterly basis (4x/year). If you have an immediate request, please go through the normal channels of contacting staff or submitting a support request.


### PR DESCRIPTION
Previously, the link in the README went straight to creating a blank issue so I didn't even know the templates existed until I clicked this link via the normal github new issue navigation. Hopefully, it works in the README as well.

FWIW, since you only have one issue template right now, you might consider just making that the default template for the repo (so people don't have to do an extra click to choose it), or even if you plan to add more templates later, you could find an url to link directly to the proposal template in the README since that's what text is advertising for that specific link.